### PR TITLE
GSM shield examples and minor optimisations

### DIFF
--- a/XivelyClient.cpp
+++ b/XivelyClient.cpp
@@ -2,6 +2,11 @@
 #include <HttpClient.h>
 #include <CountingStream.h>
 
+// Initialize constants
+const char* XivelyClient::kUserAgent = "Xively-Arduino-Lib/1.0";
+const char* XivelyClient::kApiHost = "api.xively.com";
+const char* XivelyClient::kApiKeyHeader = "X-ApiKey";
+
 XivelyClient::XivelyClient(Client& aClient)
   : _client(aClient)
 {
@@ -13,11 +18,10 @@ int XivelyClient::put(XivelyFeed& aFeed, const char* aApiKey)
   char path[30];
   buildPath(path, aFeed.id(), "json");
   http.beginRequest();
-  int ret = http.put("api.xively.com", path);
+  int ret = http.put(kApiHost, path, kUserAgent);
   if (ret == 0)
   {
-    http.sendHeader("X-ApiKey", aApiKey);
-    http.sendHeader("User-Agent", "Xively-Arduino-Lib/1.0");    
+    http.sendHeader(kApiKeyHeader, aApiKey);
 
     CountingStream countingStream; // Used to work out how long that data will be
     for (int i =kCalculateDataLength; i <= kSendData; i++)
@@ -36,7 +40,7 @@ int XivelyClient::put(XivelyFeed& aFeed, const char* aApiKey)
       if (i == kCalculateDataLength)
       {
         // We now know how long the data will be...
-        http.sendHeader("Content-Length", len);
+        http.sendHeader(HTTP_HEADER_CONTENT_LENGTH, len);
       }
     }
     // Now we're done sending the request
@@ -75,11 +79,10 @@ int XivelyClient::get(XivelyFeed& aFeed, const char* aApiKey)
   char path[30];
   buildPath(path, aFeed.id(), "csv");
   http.beginRequest();
-  int ret = http.get("api.xively.com", path);
+  int ret = http.get(kApiHost, path, kUserAgent);
   if (ret == 0)
   {
-    http.sendHeader("X-ApiKey", aApiKey);
-    http.sendHeader("User-Agent", "Xively-Arduino-Lib/1.0");    
+    http.sendHeader(kApiKeyHeader, aApiKey);
     http.endRequest();
 
     ret = http.responseStatusCode();

--- a/XivelyClient.h
+++ b/XivelyClient.h
@@ -14,6 +14,9 @@ public:
   int put(XivelyFeed& aFeed, const char* aApiKey);
 
 protected:
+  static const char* kUserAgent;
+  static const char* kApiHost;
+  static const char* kApiKeyHeader;
   static const int kCalculateDataLength =0;
   static const int kSendData =1;
   void buildPath(char* aDest, unsigned long aFeedId, const char* aFormat);

--- a/XivelyDatastream.cpp
+++ b/XivelyDatastream.cpp
@@ -1,6 +1,4 @@
 #include <XivelyDatastream.h>
-// FIXME Only needed until readStringUntil is available in Stream
-#include <Arduino.h>
 
 XivelyDatastream::XivelyDatastream(String& aId, int aType)
   : _idType(DATASTREAM_STRING), _valueType(aType), _idString(aId)
@@ -40,30 +38,10 @@ int XivelyDatastream::updateValue(Stream& aStream)
     }
     break;
   case DATASTREAM_STRING:
-    // FIXME Change this to use readStringUntil once that's in the core
-    // FIMXE and remove the timedRead method in here then too
-    _valueString = "";
-    int c = timedRead(aStream);
-    while (c >= 0 && c != '\n')
-    {
-      _valueString += (char)c;
-      c = timedRead(aStream);
-    }
+    _valueString = aStream.readStringUntil('\n');
     break;
   };
 }
-
-int XivelyDatastream::timedRead(Stream& aStream)
-{
-  int c;
-  long _startMillis = millis();
-  do {
-    c = aStream.read();
-    if (c >= 0) return c;
-  } while(millis() - _startMillis < 10000UL);
-  return -1;     // -1 indicates timeout
-}
-
 
 void XivelyDatastream::setInt(int aValue)
 {

--- a/XivelyDatastream.h
+++ b/XivelyDatastream.h
@@ -34,8 +34,6 @@ public:
 protected:
   int idLength() { return (_idType == DATASTREAM_STRING ? _idString.length() : strlen(_idBuffer._buffer)); };
   char idChar(int idx) { return (_idType == DATASTREAM_STRING ? _idString[idx] : (idx > strlen(_idBuffer._buffer) ? '\0' : _idBuffer._buffer[idx])); };
-  // FIXME Only needed until readStringUntil is available in core
-  int timedRead(Stream& aStream);
 
   int _idType;
   String _idString;

--- a/examples/GSMDatastreamDownload/GSMDatastreamDownload.ino
+++ b/examples/GSMDatastreamDownload/GSMDatastreamDownload.ino
@@ -1,0 +1,76 @@
+#include <SPI.h>
+#include <GSM.h>
+#include <HttpClient.h>
+#include <Xively.h>
+
+// Your phone SIM PIN Number
+#define PINNUMBER ""
+
+// Your phone APN data
+#define GPRS_APN       "GPRS_APN"  // replace your GPRS APN
+#define GPRS_LOGIN     "login"     // replace with your GPRS login
+#define GPRS_PASSWORD  "password"  // replace with your GPRS password
+
+// Your Xively key to let you upload data
+char xivelyKey[] = "YOUR_XIVELY_API_KEY";
+
+// Define the string for the datastream ID you want to retrieve
+char temperatureId[] = "DATASTREAM_ID_TO_RETRIEVE";
+
+XivelyDatastream datastreams[] = {
+  XivelyDatastream(temperatureId, strlen(temperatureId), DATASTREAM_FLOAT),
+};
+// Finally, wrap the datastreams into a feed
+XivelyFeed feed(FEED_ID_TO_RETRIEVE, datastreams, 1 /* number of datastreams */);
+
+// initialize the library instance
+GSM gsmAccess;     // include a 'true' parameter to enable debugging
+GPRS gprs;
+GSMClient client;
+XivelyClient xivelyclient(client);
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for Leonardo only
+  }
+  
+  Serial.println("Reading from Xively example");
+  Serial.println();
+
+  // connection state
+  boolean notConnected = true;
+  // After starting the modem with GSM.begin()
+  // attach the shield to the GPRS network with the APN, login and password
+  while(notConnected)
+  {
+    if((gsmAccess.begin(PINNUMBER)==GSM_READY) &
+      (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD)==GPRS_READY))
+      notConnected = false;
+    else
+    {
+      Serial.println("Not connected");
+      delay(1000);
+    }
+  }
+}
+
+void loop() {
+  int ret = xivelyclient.get(feed, xivelyKey);
+  Serial.print("xivelyclient.get returned ");
+  Serial.println(ret);
+
+  if (ret > 0)
+  {
+    Serial.println("Datastream is...");
+    Serial.println(feed[0]);
+
+    Serial.print("Temperature is: ");
+    Serial.println(feed[0].getFloat());
+  }
+
+  Serial.println();
+  delay(15000UL);
+}
+

--- a/examples/GSMDatastreamUpload/GSMDatastreamUpload.ino
+++ b/examples/GSMDatastreamUpload/GSMDatastreamUpload.ino
@@ -1,0 +1,75 @@
+#include <SPI.h>
+#include <GSM.h>
+#include <HttpClient.h>
+#include <Xively.h>
+
+// Your phone SIM PIN Number
+#define PINNUMBER ""
+
+// Your phone APN data
+#define GPRS_APN       "eseye.com" // replace your GPRS APN
+#define GPRS_LOGIN     ""    // replace with your GPRS login
+#define GPRS_PASSWORD  "" // replace with your GPRS password
+
+// Your Xively key to let you upload data
+char xivelyKey[] = "YOUR_XIVELY_API_KEY";
+
+// Analog pin which we're monitoring 
+int sensorPin = 2;
+
+// Define the strings for our datastream IDs
+char sensorId[] = "YOUR_DATASTREAM_ID";
+XivelyDatastream datastreams[] = {
+  XivelyDatastream(sensorId, strlen(sensorId), DATASTREAM_FLOAT),
+};
+// Finally, wrap the datastreams into a feed
+XivelyFeed feed(YOUR_FEED_ID, datastreams, 1 /* number of datastreams */);
+
+// initialize the library instance
+GSM gsmAccess;     // include a 'true' parameter to enable debugging
+GPRS gprs;
+GSMClient client;
+XivelyClient xivelyclient(client);
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for Leonardo only
+  }
+  
+  Serial.println("Starting single datastream upload to Xively...");
+  Serial.println();
+
+  // connection state
+  boolean notConnected = true;
+  // After starting the modem with GSM.begin()
+  // attach the shield to the GPRS network with the APN, login and password
+  while(notConnected)
+  {
+    if((gsmAccess.begin(PINNUMBER)==GSM_READY) &
+      (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD)==GPRS_READY))
+      notConnected = false;
+    else
+    {
+      Serial.println("Not connected");
+      delay(1000);
+    }
+  }
+}
+
+void loop() {
+  int sensorValue = analogRead(sensorPin);
+  datastreams[0].setFloat(sensorValue);
+
+  Serial.print("Read sensor value ");
+  Serial.println(datastreams[0].getFloat());
+
+  Serial.println("Uploading it to Xively");
+  int ret = xivelyclient.put(feed, xivelyKey);
+  Serial.print("xivelyclient.put returned ");
+  Serial.println(ret);
+
+  Serial.println();
+  delay(15000);
+}

--- a/examples/GSMMultipleDatastreamsUpload/GSMMultipleDatastreamsUpload.ino
+++ b/examples/GSMMultipleDatastreamsUpload/GSMMultipleDatastreamsUpload.ino
@@ -1,0 +1,95 @@
+#include <SPI.h>
+#include <GSM.h>
+#include <HttpClient.h>
+#include <Xively.h>
+
+// Your phone SIM PIN Number
+#define PINNUMBER ""
+
+// Your phone APN data
+#define GPRS_APN       "eseye.com" // replace your GPRS APN
+#define GPRS_LOGIN     ""    // replace with your GPRS login
+#define GPRS_PASSWORD  "" // replace with your GPRS password
+
+// Your Xively key to let you upload data
+char xivelyKey[] = "YOUR_XIVELY_API_KEY";
+
+// Analog pin which we're monitoring 
+int sensorPin = 2;
+
+// Define the strings for our datastream IDs
+// Replace these with strings that make sense for what you're recording
+char sensorId[] = "sensor_reading";
+char bufferId[] = "info_message";
+String stringId("random_string");
+const int bufferSize = 140;
+char bufferValue[bufferSize]; // enough space to store the string we're going to send
+XivelyDatastream datastreams[] = {
+  XivelyDatastream(sensorId, strlen(sensorId), DATASTREAM_FLOAT),
+  XivelyDatastream(bufferId, strlen(bufferId), DATASTREAM_BUFFER, bufferValue, bufferSize),
+  XivelyDatastream(stringId, DATASTREAM_STRING)
+};
+// Finally, wrap the datastreams into a feed
+XivelyFeed feed(YOUR_FEED_ID, datastreams, 3 /* number of datastreams */);
+
+// initialize the library instance
+GSM gsmAccess;     // include a 'true' parameter to enable debugging
+GPRS gprs;
+GSMClient client;
+XivelyClient xivelyclient(client);
+
+void setup() {
+  // put your setup code here, to run once:
+  Serial.begin(9600);
+  while (!Serial) {
+    ; // wait for serial port to connect. Needed for Leonardo only
+  }
+
+  Serial.println("Starting multiple datastream upload to Xively...");
+  Serial.println();
+
+  // connection state
+  boolean notConnected = true;
+  // After starting the modem with GSM.begin()
+  // attach the shield to the GPRS network with the APN, login and password
+  while(notConnected)
+  {
+    if((gsmAccess.begin(PINNUMBER)==GSM_READY) &
+      (gprs.attachGPRS(GPRS_APN, GPRS_LOGIN, GPRS_PASSWORD)==GPRS_READY))
+      notConnected = false;
+    else
+    {
+      Serial.println("Not connected");
+      delay(1000);
+    }
+  }
+}
+
+void loop() {
+  int sensorValue = analogRead(sensorPin);
+  datastreams[0].setFloat(sensorValue);
+
+  Serial.print("Read sensor value ");
+  Serial.println(datastreams[0].getFloat());
+
+  datastreams[1].setBuffer("a message to upload");
+  Serial.print("Setting buffer value to:\n    ");
+  Serial.println(datastreams[1].getBuffer());
+
+  // Pick a random number to send up in a string
+  String stringValue(random(100));
+  stringValue += " is a random number";
+  datastreams[2].setString(stringValue);
+  Serial.print("Setting string value to:\n    ");
+  Serial.println(datastreams[2].getString());
+
+  Serial.println("Uploading it to Xively");
+  int ret = xivelyclient.put(feed, xivelyKey);
+  Serial.print("xivelyclient.put returned ");
+  Serial.println(ret);
+
+  Serial.println();
+
+  delay(15000);
+}
+


### PR DESCRIPTION
Have added a few new examples which use the Arduino GSM shield (or the Eseye Hera200 board, which is effectively a Leonardo + GSM shield).

Unfortunately because the Leonardo has a 4KB bootloader (so less space available) and the GSM library is pretty big, only the GSMDatastreamUpload sketch will fit into a Leonardo (all should fit into an Uno).  So I've trimmed down the library a bit, and will be submitting a patch for the GSM library to the core Arduino project once I've worked a "proper" one out.

At present I've got a workaround which frees up >2KB in the GSM library, but stops voice calls working.  If you comment out these two lines in your GSM library, it'll free up enough space for all of the examples to work on a Leonardo:

In Arduino/libraries/GSM/GSM3MobileServerService.cpp:
GSM3ShieldV1ServerProvider theShieldV1ServerProvider;

And in Arduino/libraries/GSM/GSM3VoiceCallService.cpp:
GSM3ShieldV1VoiceProvider theShieldV1VoiceProvider;
